### PR TITLE
Targets - swap 2 target objects to be files & 1 target file to be an object

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -17,7 +17,7 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000",
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, site_data_file){
+nwis_site_info <- function(site_data_file){
   site_data <- readRDS(site_data_file)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -21,7 +21,7 @@ nwis_site_info <- function(fileout, site_data_file){
   site_data <- readRDS(site_data_file)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
+  return(site_info)
 }
 
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -17,7 +17,8 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000",
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(fileout, site_data_file){
+  site_data <- readRDS(site_data_file)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,18 +1,18 @@
-combine_and_process_data <- function(...){
+combine_and_process_data <- function(out_file, ...){
   nwis_data <- purrr:::map(list(...), readr::read_csv) %>% purrr::reduce(bind_rows)
   
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, tz_cd)
   
-  return(nwis_data_clean)
+  saveRDS(nwis_data_clean, out_file)
 }
 
-prepare_data_for_plot <- function(site_data_clean, site_filename){
+prepare_data_for_plot <- function(out_file, site_data_file, site_filename){
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
+  annotated_data <- left_join(readRDS(site_data_file), site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
   styled_data <- annotated_data %>% 
     mutate(station_name = as.factor(station_name))
   
-  return(styled_data)
+  saveRDS(styled_data, out_file)
 }

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -7,8 +7,7 @@ combine_and_process_data <- function(out_file, ...){
   saveRDS(nwis_data_clean, out_file)
 }
 
-prepare_data_for_plot <- function(out_file, site_data_file, site_filename){
-  site_info <- read_csv(site_filename)
+prepare_data_for_plot <- function(out_file, site_data_file, site_info){
   annotated_data <- left_join(readRDS(site_data_file), site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
   styled_data <- annotated_data %>% 

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,5 +1,5 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
-  
+plot_nwis_timeseries <- function(fileout, site_data_styled_file, width = 12, height = 7, units = 'in'){
+  site_data_styled <- readRDS(site_data_styled_file)
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
   ggsave(fileout, width = width, height = height, units = units)

--- a/remake.yml
+++ b/remake.yml
@@ -30,8 +30,9 @@ targets:
   1_fetch/out/site_data_01466500.csv:
     command: download_nwis_site_data(target_name)
   
-  site_data:
+  2_process/out/site_data.rds:
     command: combine_and_process_data(
+      target_name,
       '1_fetch/out/site_data_01427207.csv',
       '1_fetch/out/site_data_01432160.csv',
       '1_fetch/out/site_data_01435000.csv',
@@ -39,11 +40,16 @@ targets:
       '1_fetch/out/site_data_01466500.csv')
   
   1_fetch/out/site_info.csv:
-    command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
+    command: nwis_site_info(
+      fileout = '1_fetch/out/site_info.csv', 
+      site_data_file = '2_process/out/site_data.rds')
 
-  site_data_plot:
-    command: prepare_data_for_plot(site_data, site_filename = '1_fetch/out/site_info.csv')
+  2_process/out/site_data_plot.rds:
+    command: prepare_data_for_plot(
+      target_name, 
+      site_data_file = '2_process/out/site_data.rds', 
+      site_filename = '1_fetch/out/site_info.csv')
 
   3_visualize/out/figure_1.png:
     command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 
-      site_data_plot)  
+      '2_process/out/site_data_plot.rds')  

--- a/remake.yml
+++ b/remake.yml
@@ -39,16 +39,15 @@ targets:
       '1_fetch/out/site_data_01436690.csv',
       '1_fetch/out/site_data_01466500.csv')
   
-  1_fetch/out/site_info.csv:
+  site_info:
     command: nwis_site_info(
-      fileout = '1_fetch/out/site_info.csv', 
       site_data_file = '2_process/out/site_data.rds')
 
   2_process/out/site_data_plot.rds:
     command: prepare_data_for_plot(
       target_name, 
       site_data_file = '2_process/out/site_data.rds', 
-      site_filename = '1_fetch/out/site_info.csv')
+      site_info = site_info)
 
   3_visualize/out/figure_1.png:
     command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 


### PR DESCRIPTION
Working on #7 - I changed the combined site data object target `site_data` and the plot-ready object target `site_data_plot` into `.rds` file targets. Additionally, I changed the `1_fetch/out/site_info.csv` file target to be an object instead.

I do not have anything in `build/status` to comment here.