### PR TITLE
gitignore `/out` files?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 
 .remake/*
+
+*/out


### PR DESCRIPTION
I closed that other branch and then realized I did have a question. I noticed that the `.gitignore` file was not ignoring file outputs and so I added `*/out` to the file. I am wondering two things: 1) Will gitignoring outputs be discussed in the next pipelines course?, and 2) is `*/out` too restrictive? Are there ever files in `out` that we would want to not gitignore?